### PR TITLE
Adjust variable selector and yt-endpoint-color variable

### DIFF
--- a/YouTubeDeepDarkMaterial.css
+++ b/YouTubeDeepDarkMaterial.css
@@ -128,7 +128,7 @@
 	}
 	
 	/*Variable changes*/
-	:not([style-scope]):not(.style-scope) 
+  html:not([style-scope]):not(.style-scope):not([color-exp]) *, html[color-exp]:not([style-scope]):not(.style-scope)
 	{
 		--yt-primary-color: var(--main-text) !important;
 		--yt-primary-text-color: var(--main-text) !important;
@@ -154,7 +154,8 @@
 		--yt-icon-hover-color: var(--main-color) !important;
 		--yt-icon-active-color: var(--main-color) !important;
 		--yt-icon-disabled-color: var(--hover-background) !important;
-		--yt-endpoint-color: var(--hover-background) !important;
+		/* --yt-endpoint-color: var(--hover-background) !important; */
+		--yt-endpoint-color: var(--main-color) !important;
 		--yt-expand-color: var(--dimer-text) !important;
 		--yt-metadata-color: var(--dimer-text) !important;
 		--yt-channel-owner: var(--main-color) !important;


### PR DESCRIPTION
The selector for the variables changed, so the style wasn't overriding YouTube's in part of the page.

The `--yt-endpoint-color` variable was using a dim color. I changed it to use `--main-color` but I forgot what the original was supposed to look like so feel free to adjust.

PS: I've selected "Allow edits from maintainers" but if it turns itself off for some reason, like last time, tell me and I'll switch it back on.