### PR TITLE
Fix YouTube Music progressbar color

### DIFF
--- a/YouTubeDeepDarkMaterial.user.css
+++ b/YouTubeDeepDarkMaterial.user.css
@@ -3567,6 +3567,18 @@
 	}
 
 	/*Music*/
+	/* scrubber button */
+	.tp-yt-paper-slider.style-scope.slider-knob-inner
+	{
+		background: var(--main-color) !important;
+		border-color: var(--main-color) !important;
+	}
+	/* progress bar */
+	#primaryProgress
+	{
+		background: var(--main-color) !important;
+		border-color: var(--main-color) !important;
+	}
 	.flex-container.ytd-compact-station-renderer
 	{
 		background-color: var(--second-background) !important;


### PR DESCRIPTION
Change YouTube Music progressbar red color ([example](https://music.youtube.com/watch?v=Wct8-YuTOnE&list=OLAK5uy_lSDJbtcT2aKm98YiSIfo1i8pc1nZFNB5s))
![0](https://user-images.githubusercontent.com/14265316/146455063-8a75dec4-f81c-4270-9869-acb9a158ea38.png)
to blue as on common videos
![1](https://user-images.githubusercontent.com/14265316/146455091-425afbe4-6ea6-48e2-bf28-9ce20598c274.png)