### PR TITLE
Add exclusion to secondary for setting background colour

### DIFF
--- a/YouTubeDeepDarkMaterial.user.css
+++ b/YouTubeDeepDarkMaterial.user.css
@@ -458,7 +458,7 @@
 	}
 
 	/*Background for the entire page*/
-	html, ytd-browse, ytd-watch, ytd-search, ytd-app, ytd-app[is-watch-page], [class*="ytd-watch-flexy"]:not(#engagement-panel-scrim),
+	html, ytd-browse, ytd-watch, ytd-search, ytd-app, ytd-app[is-watch-page], [class*="ytd-watch-flexy"]:not(#engagement-panel-scrim):not(#secondary):not(#secondary-split-scroll-spacer),
 	.style-scope.ytd-page-manager.hide-skeleton,
 	.account-container
 	{


### PR DESCRIPTION
The new youtube layout made `div#secondary-split-scroll-spacer.ytd-watch-flexy` (and by extension `div#secondary.ytd-watch-flexy`) display over the video panel.
<img width="666" height="158" alt="image" src="https://github.com/user-attachments/assets/a39e193e-a1b4-44cc-932b-5eb93a228146" />
Setting the background colour on this makes the video panel "invisible", so this PR excludes it from the background 
Fixes #123


Screenshot of bug:
<img width="2547" height="1267" alt="image" src="https://github.com/user-attachments/assets/1f5f0957-6873-4259-9c2b-16ca61ef5d1f" />

Screenshot after change:
<img width="2551" height="1271" alt="image" src="https://github.com/user-attachments/assets/3186a8d8-73f7-42cd-8e76-3c704611c87c" />
